### PR TITLE
Cutoff long commit messages

### DIFF
--- a/git-graph.rb
+++ b/git-graph.rb
@@ -164,7 +164,7 @@ def log_for(commit)
   commit_msg = commit.message.gsub(%r|git-svn-id: .*$|, "")
   cutoff = 297
   if commit_msg.length > cutoff+3
-    commit_msg = commit_msg.slice(0,cutoff) + " ... (#{commit_msg.length-cutoff} more)"
+    commit_msg = commit_msg.slice(0,cutoff) + " ... (#{commit_msg.length-cutoff} longer)"
   end
   wrap_text(commit_msg + " [" + id_for(commit) + "]").fast_xs.fast_xs.gsub(%r|\n|, "<br/>")
 end

--- a/git-graph.rb
+++ b/git-graph.rb
@@ -161,7 +161,12 @@ end
 
 def log_for(commit)
   #escape twice so that xml entities end up correct in svg files
-  wrap_text(commit.message.gsub(%r|git-svn-id: .*$|, "") + " [" + id_for(commit) + "]").fast_xs.fast_xs.gsub(%r|\n|, "<br/>")
+  commit_msg = commit.message.gsub(%r|git-svn-id: .*$|, "")
+  cutoff = 297
+  if commit_msg.length > cutoff+3
+    commit_msg = commit_msg.slice(0,cutoff) + " ... (#{commit_msg.length-cutoff} more)"
+  end
+  wrap_text(commit_msg + " [" + id_for(commit) + "]").fast_xs.fast_xs.gsub(%r|\n|, "<br/>")
 end
 
 def fixed(str)


### PR DESCRIPTION
When commit messages of commits are very long, these will create very large commit nodes because of all the text. This change cuts off commit messages longer than 300 characters (297+3).

I believe the graphs (linking between commit nodes) are more important than what's in the commit message.
